### PR TITLE
Return response.body as message for http checks

### DIFF
--- a/lib/rx/check/http_check.rb
+++ b/lib/rx/check/http_check.rb
@@ -18,6 +18,7 @@ module Rx
           http.use_ssl = url.scheme == "https"
 
           response = http.request(Net::HTTP::Get.new(path))
+          raise StandardError.new(response.body) unless response.code == "200"
           response.code == "200"
         end
       end

--- a/test/rx/check/http_check_test.rb
+++ b/test/rx/check/http_check_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "net/http"
 
 class HttpCheckTest < Minitest::Test
-  MockResponse = Struct.new(:code)
+  MockResponse = Struct.new(:code, :body)
 
   def setup
     @check = Rx::Check::HttpCheck.new("http://example.com")
@@ -24,6 +24,16 @@ class HttpCheckTest < Minitest::Test
     Net::HTTP.stub :new, @http do
       res = @check.check
       assert !res.ok?
+    end
+  end
+
+  def test_it_contains_response_body_in_error
+    dummy_error_message = "Dummy error message"
+    @http.expect :request, MockResponse.new("500", dummy_error_message), [Net::HTTP::Get]
+    Net::HTTP.stub :new, @http do
+      res = @check.check
+      assert !res.ok?
+      assert_equal dummy_error_message, res.error.message
     end
   end
 


### PR DESCRIPTION
I think it would help during debugging or investigating incidents if the users of the library could see what exactly went wrong with the http checks.

I tested in irb, and `http.request(Net::HTTP::Get.new(path))` does not raise errors in case of non 2xx or 3xx responses, but returns normally for both 4xx or 5xx (tested with 404 and 503). In these cases all we saw in the healthcheck response was something like the following for an http check:
```
{
 "message": null,
 "name": "My Service",
 "response_time_ms": 52.27,
 "status": 503
}
```

It is because in these cases the result = yield line (in lib/rx/check/result.rb:10) never threw an error, just set result to false (as the response code did not equal "200")

When we wanted to help out another team within our organization, we were only able to tell them that their readiness check returned non 200 status code, and thats it.

What do you think about the change?

